### PR TITLE
(bug) Add new permissions for sveltos-applier

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -575,6 +575,15 @@ rules:
   - list
   - update
   - watch
+- apiGroups:
+  - lib.projectsveltos.io
+  resources:
+  - classifierreports/reports
+  - eventreports/reports
+  - healthcheckreports/reports
+  verbs:
+  - get
+  - update
 `
 
 var clusterRole = `apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Sveltos-applier needs to reset the report statuses for
- EventReport
- HealthCheckReport
- ClassifierReport

This allows counter parts on the control cluster (event-manager, healthcheck-manaegr and classifier-manager) to only process reports which have not been processed yet.